### PR TITLE
Make Canary targetting easy

### DIFF
--- a/nomad/traefik/Makefile
+++ b/nomad/traefik/Makefile
@@ -52,9 +52,10 @@ endif
 .PHONY: stop-nomad
 stop-nomad:
 	@echo "Stopping nomad"
-	kill -9 $(shell ps -ef | grep 'nomad' | grep -v grep | cut -d' ' -f4)
-	@echo "Listing running nomad (should not show anything)"
-	@ps -ef | grep 'nomad' | grep -v grep || true
+	@pkill -SIGINT -l -f 'nomad agent -dev'
+	@echo "Waiting for nomad to drain all tasks and exit..."
+	@timeout 13s bash -c "while pkill -0 -f 'nomad agent -dev' 2> /dev/null; do sleep 1; done" || \
+		(echo "Nomad did not shutdown in time, hard killing it. Tasks may still be running!" >&2 && pkill -SIGKILL -f 'nomad agent -dev')
 
 .PHONY: start-traefik
 start-traefik:

--- a/nomad/traefik/webapp.nomad.hcl
+++ b/nomad/traefik/webapp.nomad.hcl
@@ -34,14 +34,26 @@ job "demo-webapp" {
 
       tags = [
         "tag=${var.tag}",
+        "traefik.hcp.name=myapp",
         "traefik.enable=true",
-        "traefik.http.routers.demo-webapp.rule=Path(`/myapp`)",
+        "traefik.http.routers.${NOMAD_JOB_ID}.priority=10",
+        "traefik.http.services.${NOMAD_JOB_ID}.loadbalancer.server.weight=5",
       ]
       canary_tags = [
         "tag=${var.tag}",
         "traefik.enable=true",
-        "traefik.http.routers.demo-webapp-canary.rule=Path(`/myapp`) && Header(`canary`,`true`)",
+        "traefik.hcp.name=myapp",
+        # Setting canary creates a temporary router for this service.
+        # e.g. `${NOMAD_JOB_ID}-4989265017458556597`
         "traefik.consulcatalog.canary=true",
+
+        # To add canary to stable cluster routing and receive % of traffic, add:
+#         # LB_WRR(canary, stable)
+#         "traefik.http.services.${NOMAD_JOB_ID}.loadbalancer.server.weight=50",
+#         # LV_WRR(canary)
+#         "traefik.http.routers.${NOMAD_JOB_ID}-canary.priority=50",
+#         "traefik.http.routers.${NOMAD_JOB_ID}-canary.service=${NOMAD_JOB_ID}-canary",
+#         "traefik.http.services.${NOMAD_JOB_ID}-canary.loadbalancer.server.weight=50",
       ]
 
       check {


### PR DESCRIPTION
Adds HCP-like defaultRoute rule which would have been a big pain otherwise.

Adds debug logging to traefix because.

Adds canary-only routing support with optional WRR example. Likely do not recommend WRR on the stable targets. But it is possible, so I'm showing how.